### PR TITLE
Incresed waiting time for server

### DIFF
--- a/wait_for_documentserver_start.sh
+++ b/wait_for_documentserver_start.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 echo "Sleep for waiting documentserver start"
-sleep 60
+sleep 120
 echo "Waiting is end. Run tests"
 exec rspec


### PR DESCRIPTION
Increased the startup time of the server to 90 seconds
For reliability, I increase the test run time to 120 s

https://github.com/ONLYOFFICE/Docker-DocumentServer/commit/eddbbbf3eb212df18278b35b44b814743c996bec#diff-dad7b84674fccc140b0fb2f17af742872a2f5cda5ddd36af501f39b404baf0cbR39