### PR TITLE
Fix check palladium token file

### DIFF
--- a/helpers/pretests_check.rb
+++ b/helpers/pretests_check.rb
@@ -58,8 +58,9 @@ class PretestsCheck
   def self.palladium_token?
     status = false
     status = true if File.size("#{ENV['HOME']}/.palladium/token") > 1
-    status = true if ENV['PALLADIUM_TOKEN']
-    OnlyofficeLoggerHelper.log('Palladium token was not found in the "PALLADIUM TOKEN variable" or in the local directory') unless status
+    status = true unless ENV['PALLADIUM_TOKEN'].nil?
+  rescue Errno::ENOENT
+    OnlyofficeLoggerHelper.log("#{$!}") unless status
     status
   end
 end

--- a/helpers/pretests_check.rb
+++ b/helpers/pretests_check.rb
@@ -57,7 +57,7 @@ class PretestsCheck
 
   def self.palladium_token?
     status = false
-    status = true if File.file?("#{ENV['HOME']}/.palladium/token")
+    status = true if File.size("#{ENV['HOME']}/.palladium/token") > 1
     status = true if ENV['PALLADIUM_TOKEN']
     OnlyofficeLoggerHelper.log('Palladium token was not found in the "PALLADIUM TOKEN variable" or in the local directory') unless status
     status

--- a/helpers/pretests_check.rb
+++ b/helpers/pretests_check.rb
@@ -59,8 +59,9 @@ class PretestsCheck
     status = false
     status = true if File.size("#{ENV['HOME']}/.palladium/token") > 1
     status = true unless ENV['PALLADIUM_TOKEN'].nil?
-  rescue Errno::ENOENT
-    OnlyofficeLoggerHelper.log("#{$!}") unless status
     status
+  rescue Errno::ENOENT => e
+    OnlyofficeLoggerHelper.log(e.to_s) unless status
+    false
   end
 end

--- a/helpers/pretests_check.rb
+++ b/helpers/pretests_check.rb
@@ -56,12 +56,11 @@ class PretestsCheck
   end
 
   def self.palladium_token?
-    status = false
-    status = true if File.size("#{ENV['HOME']}/.palladium/token") > 1
-    status = true unless ENV['PALLADIUM_TOKEN'].nil?
-    status
+    return true unless File.read("#{ENV['HOME']}/.palladium/token").strip.empty?
+
+    false
   rescue Errno::ENOENT => e
-    OnlyofficeLoggerHelper.log(e.to_s) unless status
+    OnlyofficeLoggerHelper.log(e.to_s)
     false
   end
 end


### PR DESCRIPTION
Scenario - an empty token

Since this [line of code](https://github.com/ONLYOFFICE-QA/convert-service-testing/blob/8f7b5dffa33ba3480802706116265b1ad68fa729/Dockerfile#L16) creates an empty 1 byte file, I added a check for this