### PR TITLE
Fix run current spec file

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,11 @@
 #!/bin/bash
 
 ruby ./helpers/wait_for_documentserver_start.rb
-rspec spec/convertion_by_format/$CURRENT_SPEC
+
+if [[ -z $CURRENT_SPEC ]]; then
+        echo 'Run all the spec files in their entirety'
+        rspec
+    else
+        echo 'Run the spec file ' $CURRENT_SPEC
+        rspec spec/convertion_by_format/$CURRENT_SPEC
+fi

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
 #!/bin/bash
 
 ruby ./helpers/wait_for_documentserver_start.rb
-rspec $CURRENT_SPEC
+rspec spec/convertion_by_format/$CURRENT_SPEC


### PR DESCRIPTION
I encountered a problem with starting a spec file if you set CURRENT_SPEC = 'not null string'

According to the project logs, the path to the spec file is not set correctly
```
testing_project_1  | An error occurred while loading ./check_open_docx_by_screen_spec.rb.
testing_project_1  | Failure/Error: __send__(method, file)
testing_project_1  | 
testing_project_1  | LoadError:
testing_project_1  |   cannot load such file -- /convert_service_testing/check_open_docx_by_screen_spec.rb
```

I set the path directly in the file `environment.sh` because if you run the project without **CURRENT_SPEC** then all the spec files will run

However, I can add a check for the existence of the variable

```bash
if [[ -v $CURRENT_SPEC ]]
then
    rspec spec/convertion_by_format/$CURRENT_SPEC
else
    rspec
```
