### PR TITLE
file exclusion

### DIFF
--- a/spec/functional/documents/docx_to_odt_functional_spec.rb
+++ b/spec/functional/documents/docx_to_odt_functional_spec.rb
@@ -12,6 +12,9 @@ describe 'Convert docx to odt by convert service' do
 
   (files - result_sets.map { |result_set| "docx/#{result_set}" }).each do |file_path|
     it File.basename(file_path) do
+      if file_path == 'docx/Office Open XML Part 4 - Markup Language Reference.docx'
+        pending 'Need to increase the file size limit in document server'
+      end
       s3.download_file_by_name(file_path, './files_tmp')
       @metadata = converter.perform_convert(url: file_uri(file_path), outputtype: 'odt')
       expect(@metadata[:url]).not_to be_nil

--- a/spec/functional/documents/docx_to_rtf_funcrional_spec.rb
+++ b/spec/functional/documents/docx_to_rtf_funcrional_spec.rb
@@ -12,6 +12,9 @@ describe 'Convert docx to rtf by convert service' do
 
   (files - result_sets.map { |result_set| "docx/#{result_set}" }).each do |file_path|
     it File.basename(file_path) do
+      if file_path == 'docx/Office Open XML Part 4 - Markup Language Reference.docx'
+        pending 'Need to increase the file size limit in document server'
+      end
       s3.download_file_by_name(file_path, './files_tmp')
       @metadata = converter.perform_convert(url: file_uri(file_path), outputtype: 'rtf')
       expect(@metadata[:url]).not_to be_nil

--- a/spec/functional/spreadsheets/xlsx_to_ods_functional_spec.rb
+++ b/spec/functional/spreadsheets/xlsx_to_ods_functional_spec.rb
@@ -12,6 +12,8 @@ describe 'Convert xlsx to ods by convert service' do
 
   (files - result_sets.map { |result_set| "xlsx/#{result_set}" }).each do |file_path|
     it File.basename(file_path) do
+      pending 'Need to increase the conversion timeout' if file_path == 'xlsx/Hasil Treasure 2010 Season 2.xlsx'
+      skip 'File is too big' if file_path == 'xlsx/Smaller50MB.xlsx'
       s3.download_file_by_name(file_path, './files_tmp')
       @metadata = converter.perform_convert(url: file_uri(file_path), outputtype: 'ods')
       expect(@metadata[:url]).not_to be_nil


### PR DESCRIPTION
Because it is necessary to change the default settings of the document server to work correctly