### PR TITLE
Exclude all empty files to tests

### DIFF
--- a/config/StaticData.rb
+++ b/config/StaticData.rb
@@ -18,6 +18,8 @@ class StaticData
 
   TMP_FOLDER = 'files_tmp'
 
+  EMPTY_FILES = ['empty(слайдов нет).ppt', 'empty.rtf', 'new.rtf', 'empty(пустой слайд).ppt'].freeze
+
   def self.nginx_url
     ENV['NGINX'] || 'http://nginx'
   end

--- a/spec/functional/documents/rtf_to_docx_functional_spec.rb
+++ b/spec/functional/documents/rtf_to_docx_functional_spec.rb
@@ -18,7 +18,7 @@ describe 'Convert rtf to docx by convert service' do
       expect(@metadata[:url]).not_to be_empty
       @metadata[:file_path] = FileHelper.download_file(@metadata[:url])
       expect(File).to exist(@metadata[:file_path])
-      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data
+      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data unless StaticData::EMPTY_FILES.include?(File.basename(file))
     end
   end
   after do |example|

--- a/spec/functional/documents/rtf_to_docx_functional_spec.rb
+++ b/spec/functional/documents/rtf_to_docx_functional_spec.rb
@@ -18,7 +18,9 @@ describe 'Convert rtf to docx by convert service' do
       expect(@metadata[:url]).not_to be_empty
       @metadata[:file_path] = FileHelper.download_file(@metadata[:url])
       expect(File).to exist(@metadata[:file_path])
-      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data unless StaticData::EMPTY_FILES.include?(File.basename(file))
+      unless StaticData::EMPTY_FILES.include?(File.basename(file))
+        expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data
+      end
     end
   end
   after do |example|

--- a/spec/functional/presentations/ppt_to_pptx_functional_spec.rb
+++ b/spec/functional/presentations/ppt_to_pptx_functional_spec.rb
@@ -18,7 +18,9 @@ describe 'Convert ppt to pptx by convert service' do
       expect(@metadata[:url]).not_to be_empty
       @metadata[:file_path] = FileHelper.download_file(@metadata[:url])
       expect(File).to exist(@metadata[:file_path])
-      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data unless StaticData::EMPTY_FILES.include?(File.basename(file))
+      unless StaticData::EMPTY_FILES.include?(File.basename(file))
+        expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data
+      end
     end
   end
   after do |example|

--- a/spec/functional/presentations/ppt_to_pptx_functional_spec.rb
+++ b/spec/functional/presentations/ppt_to_pptx_functional_spec.rb
@@ -18,7 +18,7 @@ describe 'Convert ppt to pptx by convert service' do
       expect(@metadata[:url]).not_to be_empty
       @metadata[:file_path] = FileHelper.download_file(@metadata[:url])
       expect(File).to exist(@metadata[:file_path])
-      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data
+      expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data unless StaticData::EMPTY_FILES.include?(File.basename(file))
     end
   end
   after do |example|


### PR DESCRIPTION
ooxml parser complains about empty files, so we exclude them