### PR TITLE
Excluding files after conversion pdf to docx from the ooxml parser check

### DIFF
--- a/config/exception_file.json
+++ b/config/exception_file.json
@@ -23,5 +23,20 @@
     "empty.rtf",
     "new.rtf",
     "empty(пустой слайд).ppt"
+  ],
+
+  "large_files_after_conversion_pdf_docx": [
+    "2001-02budgetforcurrentoperations.pdf",
+    "Barrons GRE(12th Edition).pdf",
+    "1999usc22.pdf",
+    "9562_ar.pdf",
+    "Copy of ajar_straxi.pdf",
+    "JMX_1_4_specification.pdf",
+    "acad_aug.pdf",
+    "acpd-10-3189-2010.pdf",
+    "ajar_straxi.pdf",
+    "alain_bosquet_russkaja_mat.pdf",
+    "bankenstatistik102006.pdf",
+    "bt000061.pdf"
   ]
 }

--- a/spec/functional/documents/pdf_to_docx_functional_spec.rb
+++ b/spec/functional/documents/pdf_to_docx_functional_spec.rb
@@ -18,6 +18,9 @@ describe 'Convert pdf to docx by convert service' do
       expect(@metadata[:url]).not_to be_empty
       @metadata[:file_path] = FileHelper.download_file(@metadata[:url])
       expect(File).to exist(@metadata[:file_path])
+      if StaticData::EXCEPTION_FILES['large_files_after_conversion_pdf_docx'].include?(File.basename(file_path))
+        skip('https://bugzilla.onlyoffice.com/show_bug.cgi?id=57168')
+      end
       expect(OoxmlParser::Parser.parse(@metadata[:file_path])).to be_with_data
     end
   end


### PR DESCRIPTION
Because it takes a very long time to check
https://bugzilla.onlyoffice.com/show_bug.cgi?id=57168