### PR TITLE
Created a shared volume that does not use an extra connection to the host machine

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,4 @@
 DOCSERVER_VERSION=latest
 CURRENT_SPEC=''
+
+VOLUME_ID=common_volume_001

--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
 DOCSERVER_VERSION=latest
 CURRENT_SPEC=''
 
-VOLUME_ID=common_volume_001
+VOLUME_NAME=documents_volume

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,10 @@
-version: '3'
+version: '3.9'
+
+volumes:
+  common_volume:
+    name: ${VOLUME_ID}
+    external: false
+
 services:
   documentserver:
     image: "onlyoffice/4testing-documentserver-ee:${DOCSERVER_VERSION}"
@@ -9,11 +15,11 @@ services:
       - JWT_SECRET=secret
       - JWT_HEADER=AuthorizationJwt
   nginx:
-    image: nginx:latest
+    image: nginx
     ports:
       - "3000:80"
     volumes:
-      - ./files_tmp/:/usr/share/nginx/html/
+      - common_volume:/usr/share/nginx/html/:rw
   testing_project:
     build: ./
     tty: true
@@ -25,4 +31,4 @@ services:
       - CURRENT_SPEC=${CURRENT_SPEC}
     command: ["./entrypoint.sh"]
     volumes:
-      - ./files_tmp/:/convert_service_testing/files_tmp/
+      - common_volume:/convert_service_testing/files_tmp/:rw

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: '3.9'
 
 volumes:
-  common_volume:
+  documents_volume:
     name: ${VOLUME_ID}
     external: false
 
@@ -19,7 +19,7 @@ services:
     ports:
       - "3000:80"
     volumes:
-      - common_volume:/usr/share/nginx/html/:rw
+      - documents_volume:/usr/share/nginx/html/
   testing_project:
     build: ./
     tty: true
@@ -31,4 +31,4 @@ services:
       - CURRENT_SPEC=${CURRENT_SPEC}
     command: ["./entrypoint.sh"]
     volumes:
-      - common_volume:/convert_service_testing/files_tmp/:rw
+      - documents_volume:/convert_service_testing/files_tmp/

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: '3'
 
 volumes:
   documents_volume:


### PR DESCRIPTION
I added a shared **volume** for containers that is detached from the directory on the host machine

Those containers used to connect the volume to the directory in series, creating a three-way connection

Now a shared volume will be created which will be connected to whoever needs it

[Name usage documentation](https://docs.docker.com/compose/compose-file/compose-file-v3/#name)

It will be convenient to examine volumes lists with this name, because before docker used to assign hash sums to volumes names and it was impossible to find the right one to view the data

Right now it looks like this:
```bash
docker inspect documents_volume 
```

```bash                                                                                                                                 
[
    {
        "CreatedAt": "2023-01-11T20:04:52+04:00",
        "Driver": "local",
        "Labels": {
            "com.docker.compose.project": "convert-service-testing",
            "com.docker.compose.version": "2.6.1",
            "com.docker.compose.volume": "common_volume"
        },
        "Mountpoint": "/var/lib/docker/volumes/documets_volume/_data",
        "Name": "documents_volume",
        "Options": null,
        "Scope": "local"
    }
]
```