### PR TITLE
Fix markdownlint CI: bump Node to 22

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v5
         with:
-          node-version: '16'
+          node-version: '22'
       - name: Check markdown files using `markdownlint`
         run: |
           npm install -g markdownlint-cli


### PR DESCRIPTION
The `markdownlint` job used Node 16, but the latest `markdownlint-cli` requires Node >=22, which broke the required `markdownlint` check on all open PRs (including Dependabot bumps). Bump `node-version` to 22 to fix it.